### PR TITLE
Fix MLP activations and loss for correct multi-class classification

### DIFF
--- a/MLP in markdown notebook.Rmd
+++ b/MLP in markdown notebook.Rmd
@@ -8,345 +8,136 @@ date: "2022-12-03"
 library(fastDummies)
 library(readr)
 library(palmerpenguins)
-
-```
-
-
-```{r}
 sigmoid <- function(x){
-  return(1 / (1 + exp(-x)))
+1 / (1 + exp(-x))
 }
 
 softmax <- function(x){
-  return(exp(x) / sum(exp(x)))
+exp_x <- exp(x)
+exp_x / matrix(colSums(exp_x), nrow = nrow(x), ncol = ncol(x), byrow = TRUE)
 }
-#Relu <- function(x){
- # return(max(x,0)) 
-#}
-relu <- function(x) sapply(x, function(z) max(0,z))
 
-```
-
-
-
-```{r}
+relu <- function(x) sapply(x, function(z) max(0, z))
 data(package = 'palmerpenguins')
-
 data("penguins")
 df <- penguins
-head(df)
-
-
-```
-
-
-```{r}
-
-#drop nan values
-df <- df[complete.cases(df), ] 
-# Create dummy variable
+df <- df[complete.cases(df), ]
 df <- dummy_cols(df, select_columns = "island")
 df <- dummy_cols(df, select_columns = "sex")
-# Remove  Columns in List
-df <- df[,!names(df) %in% c("island", "sex")]
-```
-
-
-
-```{r}
-#Randomly shuffle the dataset rows (repeatedly shuffled for 5 times)
+df <- df[, !names(df) %in% c("island", "sex")]
 rows_count <- nrow(df)
-for(k in 1:5){
-  df <-df[sample(rows_count),]
+for (k in 1:5) {
+df <- df[sample(rows_count), ]
+}
+df[c(2,3,4,5,6)] <- lapply(df[c(2,3,4,5,6)], scale)
+
+validation_instances <- sample(nrow(df), nrow(df)/5)
+test <- df[validation_instances, ]
+train <- df[-validation_instances, ]
+
+X_train <- t(as.matrix(train[, -1]))
+X_test  <- t(as.matrix(test[, -1]))
+
+y_train <- t(model.matrix(~ species - 1, data = train))
+y_test  <- t(model.matrix(~ species - 1, data = test))
+getLayerSize <- function(X, y, hidden_neurons){
+list(
+n_x = nrow(X),
+n_h = hidden_neurons,
+n_y = nrow(y)
+)
+}
+initializeParameters <- function(layer_size){
+W1 <- matrix(runif(layer_size$n_h * layer_size$n_x),
+nrow = layer_size$n_h) * 0.01
+b1 <- matrix(0, nrow = layer_size$n_h, ncol = 1)
+
+W2 <- matrix(runif(layer_size$n_y * layer_size$n_h),
+nrow = layer_size$n_y) * 0.01
+b2 <- matrix(0, nrow = layer_size$n_y, ncol = 1)
+
+list(W1 = W1, b1 = b1, W2 = W2, b2 = b2)
+}
+forwardPropagation <- function(X, params){
+m <- ncol(X)
+
+Z1 <- params$W1 %*% X + matrix(rep(params$b1, m), nrow = nrow(params$b1))
+A1 <- tanh(Z1)
+
+Z2 <- params$W2 %*% A1 + matrix(rep(params$b2, m), nrow = nrow(params$b2))
+A2 <- softmax(Z2)
+
+list(Z1 = Z1, A1 = A1, Z2 = Z2, A2 = A2)
+}
+computeCost <- function(y, A2){
+m <- ncol(y)
+-sum(y * log(A2 + 1e-8)) / m
+}
+backwardPropagation <- function(X, y, cache, params){
+m <- ncol(X)
+
+dZ2 <- cache$A2 - y
+dW2 <- (1/m) * dZ2 %*% t(cache$A1)
+db2 <- matrix((1/m) * rowSums(dZ2), nrow = nrow(dZ2))
+
+dZ1 <- (t(params$W2) %*% dZ2) * (1 - cache$A1^2)
+dW1 <- (1/m) * dZ1 %*% t(X)
+db1 <- matrix((1/m) * rowSums(dZ1), nrow = nrow(dZ1))
+
+list(dW1 = dW1, db1 = db1, dW2 = dW2, db2 = db2)
+}
+updateParameters <- function(params, grads, lr){
+params$W1 <- params$W1 - lr * grads$dW1
+params$b1 <- params$b1 - lr * grads$db1
+params$W2 <- params$W2 - lr * grads$dW2
+params$b2 <- params$b2 - lr * grads$db2
+params
+}
+trainModel <- function(X, y, epochs, hidden_neurons, lr){
+layer_size <- getLayerSize(X, y, hidden_neurons)
+params <- initializeParameters(layer_size)
+cost_history <- c()
+
+for (i in 1:epochs) {
+cache <- forwardPropagation(X, params)
+cost <- computeCost(y, cache$A2)
+grads <- backwardPropagation(X, y, cache, params)
+params <- updateParameters(params, grads, lr)
+cost_history <- c(cost_history, cost)
+
+if (i %% 1000 == 0) {
+  cat("Iteration", i, "| Cost:", cost, "\n")
 }
 
-```
-
-
-
-```{r}
-#scale data
-df[c(2,3,4,5,6)] <- lapply(df[c(2,3,4,5,6)], function(x) c(scale(x)))
-validation_instances <- sample(nrow(df)/5)
-test <- df[validation_instances,] #1/3 rd validation set
-train <- df[-validation_instances,] #2/3 rd training set
-
-X_train <- train[, -1]
-X_test <- test[, -1]
-
-y_train <- model.matrix(~ species-1, data = train)
-y_test <- model.matrix(~ species-1, data = test)
-X_train <- as.matrix(X_train, byrow=TRUE)
-
-X_train <- t(X_train)
-y_train <- t(y_train)
-
-X_test <- as.matrix(X_test, byrow=TRUE)
-X_test <- t(X_test)
-y_test <- t(y_test)
-
-```
-
-
-get the different parameters of layer size
-
-```{r}
-getLayerSize <- function(X, y, hidden_neurons, train=TRUE) {
-  n_x <- dim(X)[1]
-  n_h <- hidden_neurons
-  n_y <- dim(y)[1]  
-  
-  size <- list("n_x" = n_x,
-               "n_h" = n_h,
-               "n_y" = n_y)
-  
-  return(size)
-}
-```
-
-
-Initialize Parameters
-
-```{r}
-initializeParameters <- function(X, list_layer_size){
-  
-  m <- dim(data.matrix(X))[2]
-  
-  n_x <- list_layer_size$n_x
-  n_h <- list_layer_size$n_h
-  n_y <- list_layer_size$n_y
-  
-  W1 <- matrix(runif(n_h * n_x), nrow = n_h, ncol = n_x, byrow = TRUE) * 0.001
-  b1 <- matrix(rep(0, n_h), nrow = n_h)
-  W2 <- matrix(runif(n_y * n_h), nrow = n_y, ncol = n_h, byrow = TRUE) * 0.001
-  b2 <- matrix(rep(0, n_y), nrow = n_y)
-  
-  params <- list("W1" = W1,
-                 "b1" = b1, 
-                 "W2" = W2,
-                 "b2" = b2)
-  
-  return (params)
 }
 
-```
-
-Forwardpropagation
-
-```{r}
-forwardPropagation <- function(X, params, list_layer_size){
-  
-  m <- dim(X)[2]
-  n_h <- list_layer_size$n_h
-  n_y <- list_layer_size$n_y
-  
-  W1 <- params$W1
-  b1 <- params$b1
-  W2 <- params$W2
-  b2 <- params$b2
-  
-  b1_new <- matrix(rep(b1, m), nrow = n_h)
-  b2_new <- matrix(rep(b2, m), nrow = n_y)
-
-  
-  Z1 <- W1 %*% X + b1_new
-  A1 <- Z1
-  Z2 <- W2 %*% A1 + b2_new
-  A2 <- sigmoid(Z2)
-  
-  cache <- list("Z1" = Z1,
-                "A1" = A1, 
-                "Z2" = Z2,
-                "A2" = A2)
-  
-  return (cache)
+list(params = params, cost_hist = cost_history)
 }
-```
-
-calculate the cost function
-
-```{r}
-
-computeCost <- function(X, y, cache) {
-  m <- dim(X)[2]
-  A2 <- cache$A2
-  logprobs <- (log(A2) * y) + (log(1-A2) * (1-y))
-  cost <- -sum(logprobs/m) 
-  return (cost)
+EPOCHS <- 40000
+HIDDEN_NEURONS <- 50
+LEARNING_RATE <- 0.002
+train_model <- trainModel(
+X_train,
+y_train,
+epochs = EPOCHS,
+hidden_neurons = HIDDEN_NEURONS,
+lr = LEARNING_RATE
+)
+makePrediction <- function(X, params){
+cache <- forwardPropagation(X, params)
+cache$A2
+}
+y_pred_test  <- makePrediction(X_test,  train_model$params)
+y_pred_train <- makePrediction(X_train, train_model$params)
+toClass <- function(probs){
+apply(probs, 2, which.max)
 }
 
-```
+y_true_test  <- toClass(y_test)
+y_pred_test  <- toClass(y_pred_test)
 
-backward Propagation
-
-```{r}
-backwardPropagation <- function(X, y, cache, params, list_layer_size){
-  
-  m <- dim(X)[2]
-  
-  n_x <- list_layer_size$n_x
-  n_h <- list_layer_size$n_h
-  n_y <- list_layer_size$n_y
-  
-  A2 <- cache$A2
-  A1 <- cache$A1
-  W2 <- params$W2
-  
-  dZ2 <- A2 - y
-  dW2 <- 1/m * (dZ2 %*% t(A1)) 
-  db2 <- matrix(1/m * sum(dZ2), nrow = n_y)
-  db2_new <- matrix(rep(db2, m), nrow = n_y)
-  
-  dZ1 <- (t(W2) %*% dZ2) * (1 - A1^2)
-  dW1 <- 1/m * (dZ1 %*% t(X))
-  db1 <- matrix(1/m * sum(dZ1), nrow = n_h)
-  db1_new <- matrix(rep(db1, m), nrow = n_h)
-  
-  grads <- list("dW1" = dW1, 
-                "db1" = db1,
-                "dW2" = dW2,
-                "db2" = db2)
-  
-  return(grads)
-}
-```
-update Parameters
-
-```{r}
-updateParameters <- function(grads, params, learning_rate){
-  
-  W1 <- params$W1
-  b1 <- params$b1
-  W2 <- params$W2
-  b2 <- params$b2
-  
-  dW1 <- grads$dW1
-  db1 <-  grads$db1
-  dW2 <-  grads$dW2
-  db2 <-  grads$db2
-  
-  
-  W1 <- W1 - learning_rate * dW1
-  b1 <- b1 - learning_rate * db1
-  W2 <- W2 - learning_rate * dW2
-  b2 <- b2 - learning_rate * db2
-  
-  updated_params <- list("W1" = W1,
-                         "b1" = b1,
-                         "W2" = W2,
-                         "b2" = b2)
-  
-  return (updated_params)
-}
-```
-
-Train the model
-
-```{r}
-trainModel <- function(X, y, num_iteration, hidden_neurons, lr){
-  
-  layer_size <- getLayerSize(X, y, hidden_neurons)
-  init_params <- initializeParameters(X, layer_size)
-  cost_history <- c()
-  for (i in 1:num_iteration) {
-    fwd_prop <- forwardPropagation(X, init_params, layer_size)
-    cost <- computeCost(X, y, fwd_prop)
-    back_prop <- backwardPropagation(X, y, fwd_prop, init_params, layer_size)
-    update_params <- updateParameters(back_prop, init_params, learning_rate = lr)
-    init_params <- update_params
-    cost_history <- c(cost_history, cost)
-    
-    if (i %% 1000 == 0) cat("Iteration", i, " | Cost: ", cost, "\n")
-  }
-  
-  model_out <- list("updated_params" = update_params,
-                    "cost_hist" = cost_history)
-  return (model_out)
-}
-```
-
-
-```{r}
-EPOCHS = 40000
-HIDDEN_NEURONS = 50
-LEARNING_RATE = 0.002
-
-```
-
-```{r}
-train_model <- trainModel(X_train, y_train, hidden_neurons = HIDDEN_NEURONS, num_iteration = EPOCHS, lr = LEARNING_RATE)
-
-```
-create a function to Make predictions
-
-```{r}
-makePrediction <- function(X, y, hidden_neurons){
-  layer_size <- getLayerSize(X, y, hidden_neurons)
-  params <- train_model$updated_params
-  fwd_prop <- forwardPropagation(X, params, layer_size)
-  pred <- fwd_prop$A2
-  
-  return (pred)
-}
-```
-
-store the prediction of X_test in y_pred and the predictions of X_train in ypredtrain
-
-```{r}
-y_pred <- makePrediction(X_test, y_test, HIDDEN_NEURONS)
-ypredtrain <- makePrediction(X_train, y_train, HIDDEN_NEURONS)
-
-```
-
-
-convert probabilities into classes
-class 1 for 'speciesAdelie' class 2 for 'speciesChinstrap' and finally class 3 for category 'speciesGentoo'
-
-```{r}
-yy <- function(ypred){
-  ypred <- as.data.frame(t(ypred)) 
-  ypredected <- c()
-  for (i in 1:dim(ypred)[1]) {
-    aa <- max(ypred[i,])
-    if ( aa == ypred[i,][1]) {
-    ypredected <- c(ypredected, 1)
-    } else if ( aa == ypred[i,][2]) {
-    ypredected <- c(ypredected, 2)
-    } else {
-    ypredected <- c(ypredected, 3)
-    }
- 
-  }
-  return(ypredected)
-}
-```
-
-
-```{r}
-y_true <- yy(y_test)
-y_pred <- yy(y_pred)
-ypredtrain <- yy(ypredtrain)
-ytruetrain <- yy(y_train)
-
-```
-
-Plotting the cost function 
-as we can see its converging at the end
-
-```{r}
-plot(1:EPOCHS, train_model$cost_hist, type = 'l')
-```
-Confusion matrix for X_test
-
-```{r}
-
-table(y_pred, y_true)
-```
-
-confusion matrix for X_train
-
-```{r}
-table(ypredtrain, ytruetrain)
-
-```
-
+y_true_train <- toClass(y_train)
+y_pred_train <- toClass(y_pred_train)
+plot(1:EPOCHS, train_model$cost_hist, type = "l")
+table(y_pred_test, y_true_test)
+table(y_pred_train, y_true_train)


### PR DESCRIPTION
Closes #1

This PR fixes theoretical inconsistencies in the MLP implementation by:
- Adding a non-linear hidden activation (tanh)
- Using softmax for multi-class output
- Replacing binary cross-entropy with categorical cross-entropy
- Aligning backpropagation with the forward pass
